### PR TITLE
Add Strategy System

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'groovy'
 
 repositories {
+    mavenLocal()
     maven {
         url "https://plugins.gradle.org/m2/"
     }
-    mavenLocal()
 }
 
 dependencies {

--- a/common/src/main/cpp/strategy/StrategyBuilder.cpp
+++ b/common/src/main/cpp/strategy/StrategyBuilder.cpp
@@ -1,0 +1,125 @@
+#include "strategy/Strategy.h"
+#include "strategy/StrategyBuilder.h"
+
+#include <exception>
+
+using namespace curtinfrc;
+
+StrategyQueue::StrategyQueue() : Strategy() {
+  SetCanBeReused(false);
+  SetCanBeInterrupted(true);
+}
+
+std::string StrategyQueue::GetStrategyName() {
+  if (!_custom_name.empty()) {
+    return "StrategyQueue[" + _custom_name + ", n(queued): " + std::to_string(_queue.size()) + "]";
+  } else {
+    return "StrategyQueue[n(queued): " + std::to_string(_queue.size()) + "]";
+  }
+}
+
+void StrategyQueue::OnStart() { }
+
+void StrategyQueue::OnUpdate(double dt) {
+  if (!_queue.empty()) {
+    bool allFinished = true;
+    for (auto strat : _queue.front()) {
+      strat->Update(dt);
+      if (!strat->IsFinished())
+        allFinished = false;
+    }
+
+    if (allFinished) {
+      _queue.pop_front();
+      if (_queue.empty())
+        SetDone();
+    }
+  } else {
+    SetDone();
+  }
+}
+
+void StrategyQueue::OnStop() {
+  if (GetStrategyState() != StrategyState::DONE) {
+    // Something is abnormal
+    while (!_queue.empty()) {
+      for (auto strat : _queue.front()) {
+        strat->Stop(GetStrategyState());
+      }
+      _queue.pop_front();
+    }
+  }
+}
+
+StrategyQueue::node_queue_t::const_iterator StrategyQueue::begin() {
+  return _queue.cbegin();
+}
+
+StrategyQueue::node_queue_t::const_iterator StrategyQueue::end() {
+  return _queue.cend();
+}
+
+void StrategyQueue::InheritRequirements(std::shared_ptr<Strategy> strat) {
+  if (!strat->CanBeInterrupted())
+    SetCanBeInterrupted(false);
+  
+  for (auto it : strat->GetRequirements()) {
+    Requires(it);
+  }
+}
+
+StrategyBuilder *StrategyBuilder::Start() {
+  if (_q != nullptr) {
+    _q = nullptr;
+  }
+
+  _q = std::make_shared<StrategyQueue>();
+
+  return this;
+}
+
+StrategyBuilder *StrategyBuilder::Add(std::shared_ptr<Strategy> strat) {
+  if (_q == nullptr) {
+    _q = std::make_shared<StrategyQueue>();
+  }
+
+  if (_q->_queue.size() == 0)
+    _q->_queue.emplace_back();
+
+  auto &parallels = _q->_queue.back();
+  
+  for (auto it : parallels) {
+    for (auto resource : strat->GetRequirements()) {
+      if (it->IsRequiring(resource)) {
+        throw std::invalid_argument("Strategies in parallel may not use the same Systems!");
+      }
+    }
+  }
+
+  parallels.push_back(strat);
+  _q->InheritRequirements(strat);
+
+  return this;
+}
+
+StrategyBuilder *StrategyBuilder::Then() {
+  if (_q == nullptr) {
+    _q = std::make_shared<StrategyQueue>();
+  }
+
+  // If the back of the queue is empty, there's no point in adding another stage
+  if (_q->_queue.size() == 0 || _q->_queue.back().size() > 0) {
+    _q->_queue.emplace_back();
+  }
+
+  return this;
+}
+
+std::shared_ptr<StrategyQueue> StrategyBuilder::Build(std::string name) {
+  if (!name.empty()) {
+    _q->_custom_name = name;
+  }
+  std::shared_ptr<StrategyQueue> strat = _q;
+  _q = nullptr;
+  return strat;
+}

--- a/common/src/main/cpp/strategy/StrategyController.cpp
+++ b/common/src/main/cpp/strategy/StrategyController.cpp
@@ -61,6 +61,10 @@ void StrategyController::Update(double dt) {
 }
 
 bool StrategyController::DoSchedule(std::shared_ptr<Strategy> strategy, bool force) {
+  if (strategy->GetStrategyState() != StrategyState::INITIALIZED && strategy->GetStrategyState() != StrategyState::CANCELLED && !strategy->_can_reuse) {
+    throw std::invalid_argument("Cannot reuse a Strategy that has SetCanBeReused(false)");
+  }
+
   // Assert that systems exist, and that they may have an interrupted strategy
   for (StrategySystem *sys : strategy->GetRequirements()) {
     if (std::find(_impl->systems.begin(), _impl->systems.end(), sys) == _impl->systems.end()) {

--- a/common/src/main/cpp/strategy/StrategyController.cpp
+++ b/common/src/main/cpp/strategy/StrategyController.cpp
@@ -1,0 +1,61 @@
+#include "strategy/Strategy.h"
+
+#include <mutex>
+#include <exception>
+
+#include <frc/Timer.h>
+
+using namespace curtinfrc;
+
+struct StrategyController::Impl {
+  using SystemsColl = std::set<StrategySystem *>;
+
+  std::mutex systemsMtx;
+  SystemsColl systems;
+};
+
+StrategyController::StrategyController() : _impl(new Impl) { }
+StrategyController::~StrategyController() {
+  delete _impl;
+}
+
+void StrategyController::Register(StrategySystem *sys) {
+  {
+    std::lock_guard<std::mutex> lk(_impl->systemsMtx);
+    _impl->systems.insert(sys);
+  }
+}
+
+bool StrategyController::Run(std::shared_ptr<Strategy> strategy, bool force) {
+  {
+    // Assert that systems exist, and that they may have an interrupted strategy
+    std::lock_guard<std::mutex> lk(_impl->systemsMtx);
+    for (StrategySystem *sys : strategy->GetRequirements()) {
+      if (std::find(_impl->systems.begin(), _impl->systems.end(), sys) == _impl->systems.end()) {
+        throw std::invalid_argument("StrategyController does not have registered system required by " + strategy->GetStrategyName());
+      } else {
+        auto active = sys->GetActiveStrategy();
+        if (active != nullptr) {
+          bool can_interrupt = active->_can_interrupt || active == sys->GetDefaultStrategy();
+          if (!force && !can_interrupt) {
+            // Cannot interrupt, therefore cancelled.
+            strategy->Stop(StrategyState::CANCELLED);
+            return false;
+          }
+        }
+      }
+    }
+
+    // Replace the running strategy on each system
+    for (StrategySystem *sys : strategy->GetRequirements()) {
+      // sys->_pending = strategy;
+      std::lock_guard<wpi::spinlock> lk(sys->_active_mtx);
+      if (sys->_active != nullptr) {
+        sys->_active->Interrupt();
+      }
+      sys->_active = strategy;
+      sys->_active->Start();
+    }
+  }
+  return true;
+}

--- a/common/src/main/cpp/strategy/StrategyController.cpp
+++ b/common/src/main/cpp/strategy/StrategyController.cpp
@@ -2,8 +2,10 @@
 
 #include <mutex>
 #include <exception>
+#include <future>
 
 #include <frc/Timer.h>
+#include <wpi/spinlock.h>
 
 using namespace curtinfrc;
 
@@ -26,36 +28,61 @@ void StrategyController::Register(StrategySystem *sys) {
   }
 }
 
-bool StrategyController::Run(std::shared_ptr<Strategy> strategy, bool force) {
+bool StrategyController::Schedule(std::shared_ptr<Strategy> strategy, bool force) {
+  std::unique_lock<std::mutex> lock(_impl->systemsMtx, std::try_to_lock);
+
+  if (lock.owns_lock()) {
+    return DoSchedule(strategy, force);
+  } else {
+    // We're being called when we're already locked - like inside of an active strategy.
+    // Make this call asynchronous and wait for the result.
+    return std::async(&StrategyController::DoSchedule, this, strategy, force).get();
+  }
+}
+
+void StrategyController::Update(double dt) {
+  if (dt < 0) {
+    // Automatic dt finding with system clock
+    double t = frc::GetTime();
+    if (_last_update_time > 0.01) {
+      dt = t - _last_update_time;
+    } else {
+      dt = 0;
+    }
+    _last_update_time = t;
+  }
+
   {
-    // Assert that systems exist, and that they may have an interrupted strategy
     std::lock_guard<std::mutex> lk(_impl->systemsMtx);
-    for (StrategySystem *sys : strategy->GetRequirements()) {
-      if (std::find(_impl->systems.begin(), _impl->systems.end(), sys) == _impl->systems.end()) {
-        throw std::invalid_argument("StrategyController does not have registered system required by " + strategy->GetStrategyName());
-      } else {
-        auto active = sys->GetActiveStrategy();
-        if (active != nullptr) {
-          bool can_interrupt = active->_can_interrupt || active == sys->GetDefaultStrategy();
-          if (!force && !can_interrupt) {
-            // Cannot interrupt, therefore cancelled.
-            strategy->Stop(StrategyState::CANCELLED);
-            return false;
-          }
+    for (StrategySystem *sys : _impl->systems) {
+      sys->StrategyUpdate(dt);
+    }
+  }
+}
+
+bool StrategyController::DoSchedule(std::shared_ptr<Strategy> strategy, bool force) {
+  // Assert that systems exist, and that they may have an interrupted strategy
+  for (StrategySystem *sys : strategy->GetRequirements()) {
+    if (std::find(_impl->systems.begin(), _impl->systems.end(), sys) == _impl->systems.end()) {
+      throw std::invalid_argument("StrategyController does not have registered system required by " + strategy->GetStrategyName());
+    } else {
+      auto active = sys->GetActiveStrategy();
+      if (active != nullptr) {
+        bool can_interrupt = active->_can_interrupt || active == sys->GetDefaultStrategy();
+        if (!force && !can_interrupt) {
+          // Cannot interrupt, therefore cancelled.
+          strategy->Stop(StrategyState::CANCELLED);
+          return false;
         }
       }
     }
+  }
 
-    // Replace the running strategy on each system
-    for (StrategySystem *sys : strategy->GetRequirements()) {
-      // sys->_pending = strategy;
-      std::lock_guard<wpi::spinlock> lk(sys->_active_mtx);
-      if (sys->_active != nullptr) {
-        sys->_active->Interrupt();
-      }
-      sys->_active = strategy;
-      sys->_active->Start();
-    }
+  // Replace the running strategy on each system
+  for (StrategySystem *sys : strategy->GetRequirements()) {
+    // sys->_pending = strategy;
+    sys->StrategyReplace(strategy);
+    sys->StrategyStatusUpdate();
   }
   return true;
 }

--- a/common/src/main/cpp/strategy/StrategySystem.cpp
+++ b/common/src/main/cpp/strategy/StrategySystem.cpp
@@ -6,8 +6,8 @@ using namespace curtinfrc;
 
 void StrategySystem::SetDefault(std::shared_ptr<Strategy> newStrategy) {
   if (newStrategy != nullptr) {
-    if (!newStrategy->IsRequiring(this) || newStrategy->NumRequirements() > 1) {
-      throw std::invalid_argument("A default strategy must be requiring the device as its one and only requirement.");
+    if (!newStrategy->IsRequiring(this) || newStrategy->GetRequirements().size() > 1) {
+      throw std::invalid_argument("A default strategy must be requiring the system as its one and only requirement.");
     }
 
     if (!newStrategy->_can_interrupt) {
@@ -19,24 +19,27 @@ void StrategySystem::SetDefault(std::shared_ptr<Strategy> newStrategy) {
 }
 
 void StrategySystem::StrategyUpdate(double dt) {
-  std::lock_guard<wpi::spinlock> lk(_active_mtx);
-  
-  // Employ the default strategy if this one is complete
-  if (_active == nullptr || _active->IsFinished()) {
-    _active = _default;
-    if (_active != nullptr)
-      _active->Start();
-  }
-
+  StrategyStatusUpdate();
   // Run this strategy
   if (_active != nullptr && !_active->IsFinished()) {
     _active->Update(dt);
   }
+  StrategyStatusUpdate();
+}
 
+void StrategySystem::StrategyStatusUpdate() {
   // Employ the default strategy if this one is complete
   if (_active == nullptr || _active->IsFinished()) {
     _active = _default;
     if (_active != nullptr)
       _active->Start();
   }
+}
+
+void StrategySystem::StrategyReplace(std::shared_ptr<Strategy> newStrat) {
+  if (_active != nullptr) {
+    _active->Interrupt();
+  }
+  _active = newStrat;
+  _active->Start();
 }

--- a/common/src/main/cpp/strategy/StrategySystem.cpp
+++ b/common/src/main/cpp/strategy/StrategySystem.cpp
@@ -1,0 +1,42 @@
+#include "strategy/Strategy.h"
+
+#include <exception>
+
+using namespace curtinfrc;
+
+void StrategySystem::SetDefault(std::shared_ptr<Strategy> newStrategy) {
+  if (newStrategy != nullptr) {
+    if (!newStrategy->IsRequiring(this) || newStrategy->NumRequirements() > 1) {
+      throw std::invalid_argument("A default strategy must be requiring the device as its one and only requirement.");
+    }
+
+    if (!newStrategy->_can_interrupt) {
+      throw std::invalid_argument("A default strategy must be interruptable");
+    }
+  }
+  
+  _default = newStrategy;
+}
+
+void StrategySystem::StrategyUpdate(double dt) {
+  std::lock_guard<wpi::spinlock> lk(_active_mtx);
+  
+  // Employ the default strategy if this one is complete
+  if (_active == nullptr || _active->IsFinished()) {
+    _active = _default;
+    if (_active != nullptr)
+      _active->Start();
+  }
+
+  // Run this strategy
+  if (_active != nullptr && !_active->IsFinished()) {
+    _active->Update(dt);
+  }
+
+  // Employ the default strategy if this one is complete
+  if (_active == nullptr || _active->IsFinished()) {
+    _active = _default;
+    if (_active != nullptr)
+      _active->Start();
+  }
+}

--- a/common/src/main/include/strategy/Strategy.h
+++ b/common/src/main/include/strategy/Strategy.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include "strategy/StrategySystem.h"
+#include "strategy/StrategyController.h"
+
+#include <string>
+#include <memory>
+
+#include <wpi/SmallSet.h>
+
+namespace curtinfrc {
+
+enum class StrategyState {
+  INITIALIZED, RUNNING, CANCELLED, DONE, TIMED_OUT, INTERRUPTED
+};
+
+/**
+ * A 'Strategy' is a single component in a sequential chain of events or actions.
+ * 
+ * This is similar to commands in WPILib's Command-Based Programming infrastructure,
+ * but with a few key changes for our own use.
+ */
+class Strategy {
+ public:
+  /**
+   * Get the name of this Strategy
+   */
+  virtual std::string GetStrategyName() = 0;
+
+  /**
+   * Called upon the Strategy being started
+   */
+  virtual void OnStart() {}
+
+  /**
+   * Called at the same rate as the robot base class
+   * @param dt The delta time (in seconds) from the last iteration
+   */
+  virtual void OnUpdate(double dt) = 0;
+
+  /**
+   * Called upon the Strategy being put into a state of DONE, or CANCELLED
+   */
+  virtual void OnStop() {}
+
+  /**
+   * Set whether this Strategy can be interrupted by other Strategies
+   */
+  void SetCanBeInterrupted(bool canBeInterrupted) {
+    _can_interrupt = canBeInterrupted;
+  }
+
+  /**
+   * Attempt to interrupt this Strategy
+   * 
+   * @return true if it can be interrupted, false otherwise
+   */
+  bool Interrupt() {
+    if (_can_interrupt) {
+      Stop(StrategyState::INTERRUPTED);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Set this Strategy as Done
+   */
+  void SetDone() {
+    Stop(StrategyState::DONE);
+  }
+
+  /**
+   * Set the Timeout for this Strategy, in seconds.
+   * 
+   * @param seconds The timeout, in seconds.
+   */
+  void SetTimeout(double seconds) { _timeout = seconds * 1000; }
+
+  /**
+   * Get the Timeout of the Strategy, in seconds, or 0 if it does not
+   * have an associated timeout.
+   */
+  double GetTimeout() {
+    return _timeout;
+  }
+
+  /**
+   * Get the time, in seconds, since the Strategy was started.
+   */
+  double TimeSinceStarted() {
+    return _time;
+  }
+
+  /**
+   * Get the current state of the Strategy
+   */
+  StrategyState GetStrategyState() {
+    return _strategy_state;
+  }
+
+  /**
+   * Return true if the state is in any finished state.
+   */
+  bool IsFinished() {
+    return _strategy_state != StrategyState::INITIALIZED && _strategy_state != StrategyState::RUNNING;
+  }
+
+  void Requires(StrategySystem *s) {
+    if (s != nullptr) {
+      _requirements.insert(s);
+    }
+  }
+
+  bool IsRequiring(StrategySystem *s) {
+    if (s == nullptr)
+      return false;
+    return _requirements.find(s) != _requirements.end();
+  }
+
+  int NumRequirements() {
+    return _requirements.size();
+  }
+
+  wpi::SmallPtrSetImpl<StrategySystem *> &GetRequirements() {
+    return _requirements;
+  }
+
+ protected:
+  void Start() {
+    if (_strategy_state != StrategyState::RUNNING) {
+      _time = 0;
+      _strategy_state = StrategyState::RUNNING;
+      OnStart();
+    }
+  }
+
+  void Update(double dt) {
+    if (_strategy_state != StrategyState::RUNNING) {
+      Start();
+    }
+
+    if (_strategy_state == StrategyState::RUNNING) {
+      OnUpdate(dt);
+      _time += dt;
+    }
+
+    if (_timeout > 0 && _time > _timeout) {
+      Stop(StrategyState::TIMED_OUT);
+    }
+  }
+
+  void Stop(StrategyState newState) {
+    _strategy_state = newState;
+    OnStop();
+  }
+
+  friend class StrategySystem;
+  friend class StrategyController;
+
+ private:
+  double _time = 0;
+  double _timeout = 0;
+  bool _can_interrupt = false;
+  StrategyState _strategy_state = StrategyState::INITIALIZED;
+
+  wpi::SmallSet<StrategySystem *, 8> _requirements;
+};
+
+}  // namespace curtinfrc

--- a/common/src/main/include/strategy/StrategyBuilder.h
+++ b/common/src/main/include/strategy/StrategyBuilder.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "strategy/Strategy.h"
+#include <memory>
+#include <deque>
+#include <wpi/SmallVector.h>
+
+namespace curtinfrc {
+
+class StrategyQueue;
+
+/**
+ * The StrategyBuilder is a builder for a StrategyQueue - allowing for a combination of sequential
+ * and parallel actions. 
+ * 
+ * The builder operates in a queue-like manner. Each build starts with a call to Start() and is completed
+ * with a call to Build(). In between, Add() may be used to add a parallel action, and Then() may be used
+ * to move on to the next sequential action. 
+ */
+class StrategyBuilder {
+ public:
+  
+  /**
+   * Start building a sequence of Strategies.
+   */
+  StrategyBuilder *Start();
+
+  /**
+   * Add a parallel action to the current action
+   * 
+   * Parallel actions may not share the same system, they must be mutually exclusive.
+   */
+  StrategyBuilder *Add(std::shared_ptr<Strategy> strat);
+
+  /**
+   * Add a parallel action to the current action
+   * 
+   * Parallel actions may not share the same system, they must be mutually exclusive.
+   */
+  template<typename T, typename ...Args>
+  StrategyBuilder *Add(const Args ... args) {
+    return Add(std::make_shared<T>(args...));
+  }
+
+  /**
+   * Move onto the next sequential action.
+   */
+  StrategyBuilder *Then();
+
+  /**
+   * Build the final StrategyQueue. A name may be given as an optional argument.
+   * 
+   * @param name The name for the Strategy. Optional.
+   */
+  std::shared_ptr<StrategyQueue> Build(std::string name = "");
+
+ private:
+  std::shared_ptr<StrategyQueue> _q;
+};
+
+/**
+ * A StrategyQueue is a sequential queue of parallel strategies - allowing for a combination
+ * of sequential and parallel actions.
+ * 
+ * Parallel actions may not use the same system / requirements, but sequential actions may.
+ * 
+ * The StrategyQueue should not be created directly, but should be made with @ref StrategyBuilder.
+ */
+class StrategyQueue : public Strategy {
+ public:
+  using node_parallel_container_t = typename wpi::SmallVector<std::shared_ptr<Strategy>, 4>;
+  using node_queue_t = typename std::deque<node_parallel_container_t>;
+
+  StrategyQueue();
+
+  std::string GetStrategyName() override;
+
+  void OnStart() override;
+  void OnUpdate(double dt) override;
+  void OnStop() override;
+ 
+  node_queue_t::const_iterator begin();
+  node_queue_t::const_iterator end();
+
+ protected:
+  void InheritRequirements(std::shared_ptr<Strategy> strat);
+
+  std::string _custom_name = "";
+  node_queue_t _queue;
+  friend class StrategyBuilder;
+};
+
+}

--- a/common/src/main/include/strategy/StrategyController.h
+++ b/common/src/main/include/strategy/StrategyController.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <frc/Notifier.h>
+#include <memory>
+
+namespace curtinfrc {
+
+class StrategySystem;
+class Strategy;
+
+class StrategyController {
+ public:
+  StrategyController();
+  ~StrategyController();
+
+  void Register(StrategySystem *device);
+  bool Run(std::shared_ptr<Strategy> strategy, bool force = false);
+
+  template<typename T, typename ...Args>
+  bool EmplaceRun(const Args & ... args) {
+    Run(std::make_shared<T>(args...));
+  }
+
+ private:
+  double _last_notify_time = 0;
+
+  struct Impl;
+  Impl *_impl;
+};
+
+}

--- a/common/src/main/include/strategy/StrategyController.h
+++ b/common/src/main/include/strategy/StrategyController.h
@@ -8,21 +8,56 @@ namespace curtinfrc {
 class StrategySystem;
 class Strategy;
 
+/**
+ * The StrategyController is the orchestrator for everything to do with Strategies.
+ * 
+ * The StrategyController is used to start Strategies, as well as orchestrating the
+ * StrategySystems and dependencies.
+ * 
+ * This class should be used to start Strategies, and all StrategySystems should be 
+ * registered with this class. There should only be one StrategyController per Robot.
+ * 
+ * The StrategyController Update method should be called from RobotPeriodic.
+ */
 class StrategyController {
  public:
   StrategyController();
   ~StrategyController();
 
+  /**
+   * Register a StrategySystem with the controller. This must be called for the
+   * StrategySystem to be used with any Strategies ran by this class.
+   */
   void Register(StrategySystem *device);
-  bool Run(std::shared_ptr<Strategy> strategy, bool force = false);
 
-  template<typename T, typename ...Args>
-  bool EmplaceRun(const Args & ... args) {
-    Run(std::make_shared<T>(args...));
-  }
+  /**
+   * Schedule a Strategy to be ran. 
+   * 
+   * For each system the Strategy requires, it will be checked whether the Strategy
+   * is able to override the one currently running. If it can, the Strategy will be
+   * made active and the old one interrupted. If not, this function will return false
+   * and the Strategy will be marked as CANCELLED. The system can be forced into being
+   * interrupted with the force param.
+   * 
+   * @param strategy  The new strategy to schedule
+   * @param force     Should this strategy be forced? If so, all interrupt checking is
+   *                  bypassed. Use this with caution.
+   * @return          True if the new strategy was successfully applied to all systems, 
+   *                  false otherwise.
+   */
+  bool Schedule(std::shared_ptr<Strategy> strategy, bool force = false);
+
+  /**
+   * Call a single update the Strategy system. Call this from RobotPeriodic.
+   * 
+   * This updates the Strategy status for all systems, including scheduling. This is run
+   * on a slow loop.
+   */
+  void Update(double dt = -1);
 
  private:
-  double _last_notify_time = 0;
+  bool DoSchedule(std::shared_ptr<Strategy> strategy, bool force = false);
+  double _last_update_time = 0;
 
   struct Impl;
   Impl *_impl;

--- a/common/src/main/include/strategy/StrategySystem.h
+++ b/common/src/main/include/strategy/StrategySystem.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <wpi/spinlock.h>
+
+namespace curtinfrc {
+
+class Strategy;
+class StrategyController;
+
+class StrategySystem {
+ public:
+  void SetDefault(std::shared_ptr<Strategy> newStrategy);
+
+  template<typename T, typename ...Args>
+  void EmplaceDefault(const Args & ... args) {
+    SetDefault(std::make_shared<T>(args...));
+  }
+
+  std::shared_ptr<Strategy> GetActiveStrategy() {
+    return _active;
+  }
+
+  std::shared_ptr<Strategy> GetDefaultStrategy() {
+    return _default;
+  }
+
+  void StrategyUpdate(double dt);
+
+ private:
+  wpi::spinlock _active_mtx;
+  std::shared_ptr<Strategy> _active = nullptr;
+  std::shared_ptr<Strategy> _default = nullptr;
+
+  friend class StrategyController;
+};
+
+}

--- a/common/src/main/include/strategy/StrategySystem.h
+++ b/common/src/main/include/strategy/StrategySystem.h
@@ -1,34 +1,50 @@
 #pragma once
 
 #include <memory>
-#include <wpi/spinlock.h>
 
 namespace curtinfrc {
 
 class Strategy;
 class StrategyController;
 
+/**
+ * A StrategySystem is any system, plant, or device that is capable of running
+ * a Strategy.
+ * 
+ * A StrategySystem may only run one Strategy at once, but it may have a default
+ * Strategy that is run whenever the system is not taken by another.
+ * 
+ * A StrategySystem is run at its own loop frequency. 
+ */
 class StrategySystem {
  public:
+
+  /**
+   * Set the default Strategy to run. This strategy will run whenever the system
+   * is left at idle.
+   */
   void SetDefault(std::shared_ptr<Strategy> newStrategy);
 
-  template<typename T, typename ...Args>
-  void EmplaceDefault(const Args & ... args) {
-    SetDefault(std::make_shared<T>(args...));
-  }
-
+  /**
+   * Get the currently active strategy.
+   */
   std::shared_ptr<Strategy> GetActiveStrategy() {
     return _active;
   }
 
+  /**
+   * Get the default strategy.
+   */
   std::shared_ptr<Strategy> GetDefaultStrategy() {
     return _default;
   }
 
+ protected:
   void StrategyUpdate(double dt);
+  void StrategyStatusUpdate();
+  void StrategyReplace(std::shared_ptr<Strategy> newStrat);
 
  private:
-  wpi::spinlock _active_mtx;
   std::shared_ptr<Strategy> _active = nullptr;
   std::shared_ptr<Strategy> _default = nullptr;
 

--- a/common/src/test/cpp/main.cpp
+++ b/common/src/test/cpp/main.cpp
@@ -8,7 +8,7 @@
 int main(int argc, char** argv) {
   // Fixes wpilibsuite#1550
   frc::DriverStation::GetInstance();
-  frc::Wait(0.01);
+  frc::Wait(0.25);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/common/src/test/cpp/test_Strategy.cpp
+++ b/common/src/test/cpp/test_Strategy.cpp
@@ -1,0 +1,209 @@
+#include "gtest/gtest.h"
+
+#include "strategy/Strategy.h"
+
+using namespace curtinfrc;
+
+class MockStrategy : public Strategy {
+ public:
+  int started = 0, stopped = 0, periodic = 0;
+
+  std::string GetStrategyName() override {
+    return "MockStrategy";
+  }
+
+  void OnStart() override {
+    started++;
+  }
+
+  void OnUpdate(double dt) override {
+    periodic++;
+  }
+
+  void OnStop() override {
+    stopped++;
+  } 
+};
+
+class MockSystem : public StrategySystem { };
+
+class StrategyTest : public testing::Test {
+ public:
+  StrategyTest() {
+    strat = std::make_shared<MockStrategy>();
+  }
+
+  std::shared_ptr<MockStrategy> makeStrat() {
+    return std::make_shared<MockStrategy>();
+  }
+
+  MockSystem sysA, sysB;
+  StrategyController controller;
+  std::shared_ptr<MockStrategy> strat;
+};
+
+TEST_F(StrategyTest, ThrowIfSystemNotRegistered) {
+  strat->Requires(&sysA);
+
+  ASSERT_THROW(controller.Run(strat), std::invalid_argument); // Sys not registered
+}
+
+TEST_F(StrategyTest, DefaultStrategyThrowsIfNotInterruptable) {
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  ASSERT_THROW(sysA.SetDefault(strat), std::invalid_argument);
+}
+
+TEST_F(StrategyTest, DefaultStrategy) {
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  strat->SetCanBeInterrupted(true);
+  sysA.SetDefault(strat);
+
+  ASSERT_EQ(sysA.GetDefaultStrategy(), strat);
+
+  sysA.StrategyUpdate(0);
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), sysA.GetDefaultStrategy());
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
+
+  // Replaced with new Strategy
+
+  std::shared_ptr<MockStrategy> strat2 = makeStrat();
+  strat2->Requires(&sysA);
+  
+  ASSERT_TRUE(controller.Run(strat2));
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::INTERRUPTED);
+  ASSERT_EQ(sysA.GetActiveStrategy(), strat2);
+
+  ASSERT_EQ(strat2->GetStrategyState(), StrategyState::RUNNING);
+
+  // New Strategy Done
+
+  strat2->SetDone();
+  sysA.StrategyUpdate(0);
+
+  ASSERT_EQ(strat2->GetStrategyState(), StrategyState::DONE);
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), sysA.GetDefaultStrategy());
+
+  // The default strategy should have been started twice and stopped once
+  ASSERT_EQ(strat->started, 2);
+  ASSERT_EQ(strat->stopped, 1);
+}
+
+// When a non-interruptable strategy is scheduled, it cannot be overridden without force
+TEST_F(StrategyTest, RejectReplacement) {
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  std::shared_ptr<MockStrategy> strat2 = makeStrat();
+  strat2->Requires(&sysA);
+
+  ASSERT_TRUE(controller.Run(strat));
+  ASSERT_FALSE(controller.Run(strat2));
+  ASSERT_EQ(strat2->GetStrategyState(), StrategyState::CANCELLED);
+
+  ASSERT_TRUE(controller.Run(strat2, true));
+}
+
+TEST_F(StrategyTest, AcceptReplacementInterrupt) {
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+  strat->SetCanBeInterrupted(true);
+
+  std::shared_ptr<MockStrategy> strat2 = makeStrat();
+  strat2->Requires(&sysA);
+
+  ASSERT_TRUE(controller.Run(strat));
+  ASSERT_TRUE(controller.Run(strat2));
+  
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::INTERRUPTED);
+}
+
+TEST_F(StrategyTest, SystemStartsWithNoStrategies) {
+  ASSERT_EQ(sysA.GetActiveStrategy(), nullptr);
+  ASSERT_EQ(sysA.GetDefaultStrategy(), nullptr);
+}
+
+TEST_F(StrategyTest, StrategyStartsInitialized) {
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::INITIALIZED);
+}
+
+TEST_F(StrategyTest, ScheduleFull) {
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  ASSERT_TRUE(controller.Run(strat));
+  sysA.StrategyUpdate(0);
+
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::RUNNING);
+  ASSERT_EQ(strat->started, 1);
+  ASSERT_EQ(strat->periodic, 1);
+  ASSERT_EQ(strat->stopped, 0);
+
+  strat->SetDone();
+
+  ASSERT_EQ(strat->stopped, 1);
+  ASSERT_TRUE(strat->IsFinished());
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::DONE);
+}
+
+TEST_F(StrategyTest, MultiRequirements) {
+  controller.Register(&sysA);
+  controller.Register(&sysB);
+
+  strat->Requires(&sysA);
+  strat->Requires(&sysB);
+
+  ASSERT_TRUE(controller.Run(strat));
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), strat);
+  ASSERT_EQ(sysB.GetActiveStrategy(), strat);
+}
+
+// Checks a reject if any system is preoccupied
+TEST_F(StrategyTest, RejectMultiRequirements) {
+  controller.Register(&sysA);
+  controller.Register(&sysB);
+
+  strat->Requires(&sysA);
+
+  std::shared_ptr<MockStrategy> strat2 = makeStrat();
+
+  strat2->Requires(&sysA);
+  strat2->Requires(&sysB);
+
+  ASSERT_TRUE(controller.Run(strat));
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), strat);
+  ASSERT_EQ(sysB.GetActiveStrategy(), nullptr);
+
+  ASSERT_FALSE(controller.Run(strat2));
+}
+
+TEST_F(StrategyTest, AcceptMultiRequirementsInterrupt) {
+  controller.Register(&sysA);
+  controller.Register(&sysB);
+
+  strat->Requires(&sysA);
+  strat->SetCanBeInterrupted(true);
+
+  std::shared_ptr<MockStrategy> strat2 = makeStrat();
+
+  strat2->Requires(&sysA);
+  strat2->Requires(&sysB);
+
+  ASSERT_TRUE(controller.Run(strat));
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), strat);
+  ASSERT_EQ(sysB.GetActiveStrategy(), nullptr);
+
+  ASSERT_TRUE(controller.Run(strat2));
+
+  ASSERT_EQ(sysA.GetActiveStrategy(), strat2);
+  ASSERT_EQ(sysB.GetActiveStrategy(), strat2);
+}

--- a/common/src/test/cpp/test_Strategy.cpp
+++ b/common/src/test/cpp/test_Strategy.cpp
@@ -243,3 +243,37 @@ TEST_F(StrategyTest, ScheduleInStrategy) {
   ASSERT_TRUE(mrs->IsFinished());
   ASSERT_EQ(sysA.GetActiveStrategy(), strat);
 }
+
+TEST_F(StrategyTest, TimedOut) {
+  auto strat = makeStrat();
+  strat->SetTimeout(0.5);
+
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  controller.Schedule(strat);
+  controller.Update(1.0);
+
+  ASSERT_EQ(strat->GetStrategyState(), StrategyState::TIMED_OUT);
+}
+
+TEST_F(StrategyTest, ThrowsIfReuseFalse) {
+  auto strat = makeStrat();
+
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  ASSERT_TRUE(controller.Schedule(strat));
+  ASSERT_THROW(controller.Schedule(strat), std::invalid_argument);
+}
+
+TEST_F(StrategyTest, AllowReuseIfTrue) {
+  auto strat = makeStrat();
+  strat->SetCanBeReused(true);
+
+  controller.Register(&sysA);
+  strat->Requires(&sysA);
+
+  ASSERT_TRUE(controller.Schedule(strat));
+  ASSERT_NO_THROW(controller.Schedule(strat));
+}

--- a/common/src/test/cpp/test_StrategyBuild.cpp
+++ b/common/src/test/cpp/test_StrategyBuild.cpp
@@ -1,0 +1,122 @@
+#include "gtest/gtest.h"
+
+#include "strategy/Strategy.h"
+#include "strategy/StrategyBuilder.h"
+
+using namespace curtinfrc;
+
+class MockCountingStrategy : public Strategy {
+ public:
+  MockCountingStrategy(int *start_count, int *periodic_count, int *stop_count)
+              : start_count(start_count), periodic_count(periodic_count), stop_count(stop_count) {}
+
+  std::string GetStrategyName() override {
+    return "MockStrategy";
+  }
+
+  void OnStart() override {
+    if (start_count) (*start_count)++;
+  }
+
+  void OnUpdate(double dt) override {
+    if (periodic_count) (*periodic_count)++;
+    if (stopAfterSingle)
+      SetDone();
+  }
+
+  void OnStop() override {
+    if (stop_count) (*stop_count)++;
+  }
+
+  int *start_count, *periodic_count, *stop_count;
+  bool stopAfterSingle = true;
+};
+
+class MockSystem : public StrategySystem { };
+
+class StrategyBuilderTest : public testing::Test {
+ public:
+  StrategyBuilderTest() {
+    controller.Register(&sysA);
+    controller.Register(&sysB);
+  }
+
+  std::shared_ptr<MockCountingStrategy> makeStrat() {
+    std::shared_ptr<MockCountingStrategy> strat = std::make_shared<MockCountingStrategy>(&num_start, &num_periodic, &num_stop);
+    strat->Requires(&sysA);
+    return strat;
+  }
+
+  std::shared_ptr<MockCountingStrategy> makeStratB() {
+    std::shared_ptr<MockCountingStrategy> strat = std::make_shared<MockCountingStrategy>(&num_start, &num_periodic, &num_stop);
+    strat->Requires(&sysB);
+    return strat;
+  }
+
+  MockSystem sysA, sysB;
+  StrategyController controller;
+
+  int num_start = 0, num_stop = 0, num_periodic = 0;
+};
+
+TEST_F(StrategyBuilderTest, SequentialOnly) {
+  auto it = StrategyBuilder{}.Start()
+              ->Then()->Add(makeStrat())
+              ->Then()->Add(makeStrat())
+              ->Then()->Add(makeStrat())
+              ->Build();
+              
+  ASSERT_EQ(std::distance(it->begin(), it->end()), 3);
+  
+  controller.Schedule(it);
+
+  for (int i = 0; i < 3; i++) {
+    controller.Update();
+    ASSERT_EQ(num_start, i+1);
+    ASSERT_EQ(num_periodic, i+1);
+    ASSERT_EQ(num_stop, i+1);
+  }
+
+  ASSERT_TRUE(it->IsFinished());
+  ASSERT_EQ(sysA.GetActiveStrategy(), nullptr);
+}
+
+TEST_F(StrategyBuilderTest, ParallelOnly) {
+  auto it = StrategyBuilder{}.Start()
+              ->Add(makeStrat())
+              ->Add(makeStratB())
+              ->Build();
+
+  ASSERT_EQ(std::distance(it->begin(), it->end()), 1);
+  ASSERT_EQ(it->begin()->size(), 2);
+
+  controller.Schedule(it);
+
+  controller.Update();
+
+  ASSERT_EQ(num_start, 2);
+  ASSERT_EQ(num_periodic, 2);
+  ASSERT_EQ(num_stop, 2);
+
+  ASSERT_TRUE(it->IsFinished());
+  ASSERT_EQ(sysA.GetActiveStrategy(), nullptr);
+}
+
+TEST_F(StrategyBuilderTest, AnyTimeout) {
+  auto normalStrat = makeStrat();
+  normalStrat->stopAfterSingle = false;
+
+  auto it = StrategyBuilder{}.Start()->Add(normalStrat)->Build();
+  it->SetTimeout(0.5);
+
+  controller.Schedule(it);
+  controller.Update(1.0);
+
+  ASSERT_EQ(it->GetStrategyState(), StrategyState::TIMED_OUT);
+  ASSERT_EQ(normalStrat->GetStrategyState(), StrategyState::TIMED_OUT);
+}
+
+TEST_F(StrategyBuilderTest, MultiSystemResource) {
+  ASSERT_THROW(StrategyBuilder{}.Start()->Add(makeStrat())->Add(makeStrat())->Build(), std::invalid_argument);
+  ASSERT_NO_THROW(StrategyBuilder{}.Start()->Add(makeStrat())->Add(makeStratB())->Build());
+}


### PR DESCRIPTION
Adds the Strategy system from 2018, with some changes.

Strategies are like the WPILib CommandBased framework, but more geared towards our needs.

To start with, in the robot code, an instance of `curtinfrc::StrategyController` needs to be added to the Robot class, and `StrategyController::Update()` called from `RobotPeriodic()`.

## Devices

Next, any system / device can be made strategy-aware by having it inherit from `curtinfrc::StrategySystem`, e.g:

```cpp
class MyIntakeDevice : public curtinfrc::StrategySystem {};
```

You can also set a default strategy on any device, should you want to run something in default (in our case, this is teleoperated actions):

```cpp
MyIntakeDevice myDevice;

myDevice.SetDefault(/* ... */);
```

## Strategies

Strategies are made by inheriting from `curtinfrc::Strategy`. They have `OnStart()`, `OnStop()` and `OnUpdate(double dt)` methods that can be overridden to perform an action. 

In the constructor for a Strategy, you can specify a timeout, as well as any systems it requires. In `OnUpdate()`, you may set the strategy as complete by using `SetDone`, eg:

```cpp
class ElevatorLiftStrategy : public curtinfrc::Strategy {
 public:
  ElevatorLiftStrategy(Elevator &elevator, double height) : Strategy("Elevator Lift") , _elevator(elevator), _height(height) {
    Requires(&elevator);
    SetTimeout(3);    // 3 seconds
  }

  void OnStart() override {
    elevator.SetSetpoint(_height);
  }

  void OnUpdate(double dt) override {
    if (elevator.IsDone()) SetDone();
  }

  void OnStop() override {
    elevator.SetHoldPosition();
  }

 private:
  Elevator &_elevator;
  double _height;
};
``` 

You can set the Strategy to run by using `StrategyController::Schedule`. It will return true if it can run, and false otherwise.

Only one Strategy can run on each system at once. By default, you can't interrupt a running strategy, but you can call `Schedule` with `force = true` in order to override that.

## StrategyBuilder
To run multiple strategies at once, or one after another, or a combination of both, you can use `curtinfrc::StrategyBuilder`.

For example:
```cpp
auto strategy = StrategyBuilder{}.start()
                           ->Add(strat1a)
                           ->Add(strat1b)
                           ->Then()
                           ->Add(strat2)
                           ->Build();
```

That will create a strategy that will run `strat1a` and `strat1b` in parallel. Once both `strat1a` and `strat1b` are complete, `strat2` will run. 

Note that when adding parallel strategies, the same StrategySystem may not be used more than once, since each system may only have 1 active strategy. Note that this does not apply to sequence actions.

# On control loops
Strategies gives you two choices:
- Do all the work in `Strategy::OnUpdate()`
   - This only updates as fast as your robot loop, which is fine for some systems, but it relatively slow (~50Hz)
- Set the system state in `Strategy::OnUpdate()`, and run a faster control loop for your system that does the actual work
   - For systems that should run faster (like the elevator, at 100-200Hz), this is the best way to go ahead since you can keep your control loops fast. 