### PR TITLE
Sending Both Images simultaneously to shuffleboard. + overlaying images

### DIFF
--- a/vision/src/main/cpp/Display.cpp
+++ b/vision/src/main/cpp/Display.cpp
@@ -17,32 +17,29 @@
 
 #include "devices/kinect.h"
 
-Display::Display(Process &process) : _process(process), _capture(process.GetCapture()) {}
+Display::Display(std::string name, Process &process) : _name(name), _process(process), _capture(process.GetCapture()) {}
 
 void Display::Init() {
   
   _videoMode = _capture.GetVideoMode();
 
   // Set up output
-  _outputCam0 = frc::CameraServer::GetInstance()->PutVideo("USB CameraTape", _videoMode.width, _videoMode.height);
-  _outputCam1 = frc::CameraServer::GetInstance()->PutVideo("USB CameraGamePeice", _videoMode.width, _videoMode.height);
+  _output = frc::CameraServer::GetInstance()->PutVideo(_name, _videoMode.width, _videoMode.height);
 }
 
 
 void Display::Periodic() {
-  _process.CopyProcessedTrack(_imgProcessedTrack);
-  _process.CopyProcessedTrack(_imgProcessedTrackHatch);
+  _process.CopyProcessedTrack(_displayMat);
   if (_capture.IsValidFrameThresh() && _capture.IsValidFrameTrack()) {
     if (_process.GetValidThresh() && _process.GetValidTrack()) {
       #ifdef __DESKTOP__
-      if (_imgProcessedTrack.rows > 0) {
-        imshow(_process.GetProcessType(), _imgProcessedTrack);
+      if (_displayMat.rows > 0) {
+        imshow(_process.GetProcessType(), _displayMat);
       }
       cv::waitKey(1000 / 30);
     
       #else
-      _outputCam0.PutFrame(_imgProcessedTrack);
-      _outputCam1.PutFrame(_imgProcessedTrackHatch);
+      _output.PutFrame(_displayMat);
       #endif
     }
   }
@@ -50,6 +47,6 @@ void Display::Periodic() {
   else {
     std::cout << "Origin Image is Not Available" << std::endl;
   }
-  std::this_thread::sleep_for(std::chrono::duration<double>(5.0 / 90));
+  std::this_thread::sleep_for(std::chrono::duration<double>(1.0 / 30));
 }
 

--- a/vision/src/main/cpp/HatchProcessing.cpp
+++ b/vision/src/main/cpp/HatchProcessing.cpp
@@ -50,6 +50,7 @@ void HatchProcessing::Periodic() {
   Process::Periodic();
   if (_capture.IsValidFrameThresh() && _capture.IsValidFrameTrack()) {
     _capture.CopyCaptureMat(_imgProcessing);
+    _imgProcessing.copyTo(_imgProcessedTrack);
     cv::cvtColor(_imgProcessing, _imgProcessing, cv::COLOR_BGR2HSV);
 
     // Contours Blocks (Draws a convex shell over the thresholded image.)
@@ -63,8 +64,8 @@ void HatchProcessing::Periodic() {
 
     double largestArea = 0.0;
     active_contour = -1;
-    // cv::inRange(_imgProcessing, cv::Scalar(15, 110, 110), cv::Scalar(40, 255, 255), _imgProcessedTrack); // <- Debug Code
-    cv::inRange(_imgProcessing, cv::Scalar(15, 110, 100), cv::Scalar(34, 255, 255), _imgProcessing);
+    // cv::inRange(_imgProcessing, cv::Scalar(15, 100, 100), cv::Scalar(34, 255, 255), _imgProcessedTrack); // <- Debug Code
+    cv::inRange(_imgProcessing, cv::Scalar(15, 100, 100), cv::Scalar(34, 255, 255), _imgProcessing);
     
     cv::findContours(_imgProcessing, contours, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_TC89_KCOS);
     
@@ -129,7 +130,7 @@ void HatchProcessing::Periodic() {
       cv::Scalar color = cv::Scalar(rngHatch.uniform(0, 255), rngHatch.uniform(0,255), rngHatch.uniform(0,255));
       cv::drawContours(_imgProcessing, hullHatch_poly, i, color, 1, 8, std::vector<cv::Vec4i>(), 0, cv::Point());
       hatch_bounding_rect = cv::boundingRect(filteredContoursHatch[i]); // Find the bounding rectangle for biggest contour
-      _imgProcessedTrack = cv::Mat::zeros(_videoMode.height, _videoMode.width, CV_8UC3);
+      // _imgProcessedTrack = cv::Mat::zeros(_videoMode.height, _videoMode.width, CV_8UC3);
       cv::rectangle(_imgProcessedTrack, boundRectHatch[i].tl(), boundRectHatch[i].br(), color, 2, 8, 0);
       cv::circle(_imgProcessedTrack, centerHatch[i], (int)radiusHatch[i], color, 2, 8, 0);
     }
@@ -164,6 +165,7 @@ void HatchProcessing::Periodic() {
       std::stringstream offsetX;	offsetX << hatch_width_offset;
       cv::putText(_imgProcessedTrack, "xy(" + offsetX.str() + "," + offsetY.str() + ")", mcHatch[i] + cv::Point2f(-25,25), cv::FONT_HERSHEY_COMPLEX_SMALL, 1, cv::Scalar(255,0,255)); //text with distance and angle on target
     }
+    
   }
   
 }

--- a/vision/src/main/cpp/TapeProcessing.cpp
+++ b/vision/src/main/cpp/TapeProcessing.cpp
@@ -39,6 +39,7 @@ void TapeProcessing::Periodic() {
 	if (_capture.IsValidFrameThresh() && _capture.IsValidFrameTrack()) {
 
     _capture.CopyCaptureMat(_imgProcessing);
+    _imgProcessing.copyTo(_imgProcessedTrack);
 		cv::cvtColor(_imgProcessing, _imgProcessing, cv::COLOR_BGR2HSV);
     // cv::inRange(_imgProcessing, cv::Scalar(40, 0, 75), cv::Scalar(75, 255, 125), _imgProcessedTrack); <-Debug Code
     cv::inRange(_imgProcessing, cv::Scalar(40, 0, 75), cv::Scalar(75, 255, 125), _imgProcessing);
@@ -58,7 +59,7 @@ void TapeProcessing::Periodic() {
     cv::Scalar green = cv::Scalar(0, 255, 0);
     cv::Scalar red = cv::Scalar(0, 0, 255);
 
-    _imgProcessedTrack = cv::Mat::zeros(_videoMode.height, _videoMode.width, CV_8UC3);
+    // _imgProcessedTrack = cv::Mat::zeros(_videoMode.height, _videoMode.width, CV_8UC3);
     for (int i = 0; i < filteredContours.size(); i++) {
       cv::drawContours(_imgProcessedTrack, filteredContours, (int)i, blue, -1);
       cv::RotatedRect rotatedRect = cv::minAreaRect(filteredContours[i]);

--- a/vision/src/main/cpp/main.cpp
+++ b/vision/src/main/cpp/main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
 
   VisionRunner vision;
   #ifdef __DESKTOP__
-  Capture capture{1, -100};
+  Capture capture{0, -100};
   Capture captureGamePiece{0, 50};
   #else
   Capture capture{4, -100};
@@ -44,8 +44,8 @@ int main(int argc, char **argv) {
   TapeProcessing tapeProcess{capture};
   
   // Display displayBall{ballProcess};
-  Display displayHatch{hatchProcess};
-  Display displayTape{tapeProcess};
+  Display displayHatch{"Hatch Tracking", hatchProcess};
+  Display displayTape{"Tape Tracking", tapeProcess};
   
   vision.Run(capture);
   vision.Run(captureGamePiece);
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
 
   // vision.Run(displayBall);  //Displays Can't work togethor for shuffleboard
   vision.Run(displayHatch);
-  // vision.Run(displayTape);
+  vision.Run(displayTape);
 
 
   for (int i = 0; i < vision.workers.size(); i++) {

--- a/vision/src/main/include/Display.h
+++ b/vision/src/main/include/Display.h
@@ -8,21 +8,18 @@
 
 class Display : public Runnable {
  public:
-  Display(Process &process);
+  Display(std::string name, Process &process);
 
   void Init() override;
   void Periodic() override;
 
  private:
   Process &_process;
-  cs::CvSource _outputCam0;
-  cs::CvSource _outputCam1;
+  std::string _name;
+  cs::CvSource _output;
   cs::VideoMode _videoMode;
   
-  cv::Mat _imgOriginal;
-  cv::Mat _imgProcessedTrack;
-  cv::Mat _imgProcessedTrackHatch;
-  cv::Mat _imgProcessedThresh;
+  cv::Mat _displayMat;
 
   Capture &_capture;
 };


### PR DESCRIPTION
**What this PR does**  
Vision Tracking Now overlaps origin images giving drivers better view. And sends both Hatch tracking and Tape Tracking to shuffleboard and tables via ONE Tinker Board
**What does it fix/add?**  

