### PR TITLE
(Optionaly) let devices::DeployableDevice eject while stowed

### DIFF
--- a/5333/src/main/cpp/HatchIntake.cpp
+++ b/5333/src/main/cpp/HatchIntake.cpp
@@ -1,11 +1,11 @@
 #include "HatchIntake.h"
 #include "ControlMap.h"
 
-void HatchIntake::IntakingPeriodic() { // Intake
+void HatchIntake::IntakingPeriodic() { // Primary (e.g. intaking)
   _config.manipulator.SetTarget(curtinfrc::actuators::kForward);
 }
 
-void HatchIntake::OuttakingPeriodic() { // Eject
+void HatchIntake::OuttakingPeriodic() { // Reverse (e.g. ejecting)
   _config.manipulator.SetTarget(curtinfrc::actuators::kReverse);
 }
 

--- a/5333/src/main/include/BoxIntake.h
+++ b/5333/src/main/include/BoxIntake.h
@@ -11,7 +11,7 @@ using BoxIntakeState = curtinfrc::devices::DeployableDeviceState;
 struct BoxIntakeConfig : public curtinfrc::devices::DeployableDeviceConfig {
   curtinfrc::Gearbox &motors;
 
-  BoxIntakeConfig(curtinfrc::Gearbox &motorsIn, curtinfrc::actuators::BinaryActuator &actuatorIn) : curtinfrc::devices::DeployableDeviceConfig(actuatorIn), motors(motorsIn) {};
+  BoxIntakeConfig(curtinfrc::Gearbox &motorsIn, curtinfrc::actuators::BinaryActuator &actuatorIn, bool canEjectIn = true) : curtinfrc::devices::DeployableDeviceConfig(actuatorIn, canEjectIn), motors(motorsIn) {};
 };
 
 class BoxIntake : public curtinfrc::devices::DeployableDevice {

--- a/5333/src/main/include/HatchIntake.h
+++ b/5333/src/main/include/HatchIntake.h
@@ -11,7 +11,7 @@ using HatchIntakeState = curtinfrc::devices::DeployableDeviceState;
 struct HatchIntakeConfig : public curtinfrc::devices::DeployableDeviceConfig {
   curtinfrc::actuators::BinaryActuator &manipulator;
 
-  HatchIntakeConfig(curtinfrc::actuators::BinaryActuator &manipulatorIn, curtinfrc::actuators::BinaryActuator &actuatorIn) : curtinfrc::devices::DeployableDeviceConfig(actuatorIn), manipulator(manipulatorIn) {};
+  HatchIntakeConfig(curtinfrc::actuators::BinaryActuator &manipulatorIn, curtinfrc::actuators::BinaryActuator &actuatorIn, bool canEjectIn = false) : curtinfrc::devices::DeployableDeviceConfig(actuatorIn, canEjectIn), manipulator(manipulatorIn) {};
 };
 
 class HatchIntake : public curtinfrc::devices::DeployableDevice {

--- a/5333/src/main/include/RobotMap.h
+++ b/5333/src/main/include/RobotMap.h
@@ -124,7 +124,7 @@ struct RobotMap {
     curtinfrc::actuators::DoubleSolenoid solenoid{ 6, 7 };
 
 
-    BoxIntakeConfig config{ boxIntakeGearbox, solenoid };
+    BoxIntakeConfig config{ boxIntakeGearbox, solenoid, true };
   };
 
   BoxIntake boxIntake;

--- a/common/src/main/cpp/devices/DeployableDevice.cpp
+++ b/common/src/main/cpp/devices/DeployableDevice.cpp
@@ -13,14 +13,33 @@ void curtinfrc::devices::DeployableDevice::SetIntaking() {
 }
 
 void curtinfrc::devices::DeployableDevice::SetOuttaking() {
-  switch (_state) {
-   case kIntaking:
-   case kOuttaking:
-    SetState(kOuttaking);
-    break;
+  if (!_config.canEject) { // default
+    switch (_state) {
+    case kIntaking:
+    case kOuttaking:
+      SetState(kOuttaking);
+      break;
 
-   default:
-    SetState(kDeploying);
+    default:
+      SetState(kDeploying);
+      break;
+    }
+  } else { // can eject while stowed
+    switch (_state) {
+     case kIntaking:
+     case kOuttaking:
+     case kStowed:
+      SetState(kOuttaking);
+      break;
+
+     case kStowing:
+      SetState(kStowing);
+      break;
+
+     case kDeploying:
+      SetState(kDeploying);
+      break;
+    }
   }
 }
 

--- a/common/src/main/include/devices/DeployableDevice.h
+++ b/common/src/main/include/devices/DeployableDevice.h
@@ -9,8 +9,9 @@ namespace curtinfrc {
 
     struct DeployableDeviceConfig {
       actuators::BinaryActuator &actuator;
+      const bool canEject;
 
-      DeployableDeviceConfig(actuators::BinaryActuator &actuatorIn) : actuator(actuatorIn) {};
+      DeployableDeviceConfig(actuators::BinaryActuator &actuatorIn, bool canEjectIn = false) : actuator(actuatorIn), canEject(canEjectIn) {};
     };
 
     class DeployableDevice : public StateDevice<DeployableDeviceState> {


### PR DESCRIPTION
Adds an optional parameter to curtinfrc::devices::DeployableDevice that allows it to eject while stowed. UNTESTED... (@JacisNonsense when is #47 being done?!?)